### PR TITLE
Make apps, tests configurable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,14 @@
 ## Any directories that you want built and installed should go here.
-SUBDIRS = include src test apps
+
+SUBDIRS = include src
+
+if ENABLE_APPS
+SUBDIRS += apps
+endif
+
+if ENABLE_TESTS
+SUBDIRS += test
+endif
 
 ## Any directories you want a part of the distribution should be listed
 ## here, as well as have a Makefile generated at the end of configure.in
@@ -8,7 +17,7 @@ SUBDIRS = include src test apps
 DIST_SUBDIRS = $(SUBDIRS) contrib music_sample
 
 # All the rest of the distributed files
-EXTRA_DIST = bootstrap 
+EXTRA_DIST = bootstrap
 
 # Run ldconfig after installing the library:
 install-exec-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,23 @@ AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memset])
 
 # wanted by: test/test.c:10
-AC_CHECK_HEADERS([fcntl.h]) 
+AC_CHECK_HEADERS([fcntl.h])
 AC_CHECK_HEADERS([sys/ioctl.h])
+
+AC_MSG_CHECKING(--enable-apps argument)
+AC_ARG_ENABLE(apps,
+    [  --enable-apps           build and install apps.],
+    [enable_apps=$enableval],
+    [enable_apps="yes"])
+AM_CONDITIONAL([ENABLE_APPS], [test "x$enable_apps" = "xyes"])
+AC_MSG_RESULT($enable_apps)
+
+AC_MSG_CHECKING(--enable-tests argument)
+AC_ARG_ENABLE(tests,
+    [  --enable-tests          build and install tests.],
+    [enable_tests=$enableval],
+    [enable_tests="yes"])
+AC_MSG_RESULT($enable_tests)
+AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = "xyes"])
 
 AC_OUTPUT(Makefile include/Makefile src/Makefile test/Makefile apps/Makefile apps/playvtx/Makefile)


### PR DESCRIPTION
This commit adds minor changes to autotool files, in order to toggle the creation of `playvtx' and `test' binaries.

This is useful when packaging the library, and one does not wish to build and install everything else.

***

With these changes, one should be able to do:
```
./bootstrap && ./configure --enable-apps=no --enable-tests=no && make 
```